### PR TITLE
change car=* to motorcar=* on charging_station

### DIFF
--- a/master_preset.xml
+++ b/master_preset.xml
@@ -3094,7 +3094,7 @@
             <checkgroup text="Types of vehicles which can be charged" columns="4">
                 <check key="bicycle" text="Bicycle" disable_off="true"/>
                 <check key="scooter" text="Scooter" disable_off="true"/>
-                <check key="car" text="Car" disable_off="true"/>
+                <check key="motorcar" text="Car" disable_off="true"/>
                 <check key="truck" text="Truck" disable_off="true"/>
             </checkgroup>
             <space/>


### PR DESCRIPTION
Following a discussion on the tagging mailing list and on the ​wiki, we have changed the tag car=yes/no on amenity=charging_station to motorcar=yes/no to be consistent with the tag used for access. 

[in JOSM](https://josm.openstreetmap.de/ticket/18659#ticket) / [in ID](https://github.com/openstreetmap/iD/pull/7339)