### PR TITLE
Add bicycle_parking=handlebar_holder

### DIFF
--- a/master_preset.xml
+++ b/master_preset.xml
@@ -3449,8 +3449,8 @@
             <link wiki="Tag:amenity=bicycle_parking"/>
             <space/>
             <key key="amenity" value="bicycle_parking"/>
-            <combo key="bicycle_parking" text="Type" values="anchors,bollard,building,ground_slots,informal,lockers,rack,shed,stands,wall_loops"
-                display_values="Anchors,Bollard,Building,Ground slots,Informal,Lockers,Rack,Shed,Stands,Wall loops" values_context="bicycle" />
+            <combo key="bicycle_parking" text="Type" values="anchors,bollard,building,ground_slots,handlebar_holder,informal,lockers,rack,shed,stands,wall_loops"
+                display_values="Anchors,Bollard,Building,Ground slots,Handlebar holder,Informal,Lockers,Rack,Shed,Stands,Wall loops" values_context="bicycle" />
             <reference ref="optional_name"/>
             <text key="capacity" text="Capacity" value_type="integer"/>
             <reference ref="parking_access_fee_operator_surface_smoothness"/>


### PR DESCRIPTION
Following the discussion at https://lists.openstreetmap.org/pipermail/tagging/2020-June/053381.html I propose to add bicycle_parking=handlebar_holder to the presets.

Please also check if the change is technically done correctly.