### PR TITLE
Extend template for key bicycle_parking=...

### DIFF
--- a/master_preset.xml
+++ b/master_preset.xml
@@ -3471,7 +3471,7 @@
             <space/>
             <key key="amenity" value="bicycle_parking"/>
             <combo key="bicycle_parking" text="Type" values="anchors,bollard,building,floor,ground_slots,handlebar_holder,informal,lockers,rack,shed,stands,wall_loops"
-                display_values="Anchors,Bollard,Building,Floor (area without racks/stands/...),Ground slots,Handlebar holder,Informal,Lockers,Rack,Shed,Stands,Wall loops" values_context="bicycle" />
+                display_values="Anchors,Bollard,Building,Floor (area without racks/stands/...),Ground slots,Handlebar holder,Informal,Lockers,Rack,Shed,Stands,Wall loops ('wheelbenders')" values_context="bicycle" />
             <reference ref="optional_name"/>
             <text key="capacity" text="Capacity" value_type="integer"/>
             <reference ref="parking_access_fee_operator_surface_smoothness"/>

--- a/master_preset.xml
+++ b/master_preset.xml
@@ -3470,8 +3470,8 @@
             <link wiki="Tag:amenity=bicycle_parking"/>
             <space/>
             <key key="amenity" value="bicycle_parking"/>
-            <combo key="bicycle_parking" text="Type" values="anchors,bollard,building,ground_slots,handlebar_holder,informal,lockers,rack,shed,stands,wall_loops"
-                display_values="Anchors,Bollard,Building,Ground slots,Handlebar holder,Informal,Lockers,Rack,Shed,Stands,Wall loops" values_context="bicycle" />
+            <combo key="bicycle_parking" text="Type" values="anchors,bollard,building,floor,ground_slots,handlebar_holder,informal,lockers,rack,shed,stands,wall_loops"
+                display_values="Anchors,Bollard,Building,Floor (area without racks/stands/...),Ground slots,Handlebar holder,Informal,Lockers,Rack,Shed,Stands,Wall loops" values_context="bicycle" />
             <reference ref="optional_name"/>
             <text key="capacity" text="Capacity" value_type="integer"/>
             <reference ref="parking_access_fee_operator_surface_smoothness"/>


### PR DESCRIPTION
This PR contains two changes:

1. The key `bicycle_parking=floor` was introduced.
2. The informal name "wheelbenders" was added to the description of `bicycle_parking=wall_loops`