### PR TITLE
Add "Lamp mount" suitable value

### DIFF
--- a/master_preset.xml
+++ b/master_preset.xml
@@ -7781,7 +7781,7 @@
             <space/>
             <key key="highway" value="street_lamp"/>
             <combo key="lamp_type" text="Type" values="electric,floodlight,gaslight,led,sodium,solar_lamp" display_values="Electric,Floodlight,Gaslight,LED,Sodium,Solar lamp" values_context="lamp_type" match="key" />
-            <combo key="lamp_mount" text="Mounted on" values="bent_mast,straight_mast,suspended,wall" display_values="Bent mast,Straight mast,Suspended,Wall" values_context="lamp_mount" match="key" />
+            <combo key="lamp_mount" text="Mounted on" values="bent_mast,high_mast,straight_mast,suspended,wall" display_values="Bent mast,High mast,Straight mast,Suspended,Wall" values_context="lamp_mount" match="key" />
             <optional>
                 <combo key="opening_hours" text="Operation times" values="Mo-Fr 22:00-05:00" match="none" editable="true" values_no_i18n="true"/>
             </optional>


### PR DESCRIPTION
Add "High mast" as a suitable value for "lamp_mount" tag, according to "https://wiki.openstreetmap.org/wiki/Key:lamp_mount"