### PR TITLE
Add ref= to highway=street_lamp

### DIFF
--- a/master_preset.xml
+++ b/master_preset.xml
@@ -7872,6 +7872,7 @@
             <key key="highway" value="street_lamp"/>
             <combo key="lamp_type" text="Type" values="electric,floodlight,gaslight,led,sodium,solar_lamp" display_values="Electric,Floodlight,Gaslight,LED,Sodium,Solar lamp" values_context="lamp_type" match="key" />
             <combo key="lamp_mount" text="Mounted on" values="bent_mast,high_mast,straight_mast,suspended,wall" display_values="Bent mast,High mast,Straight mast,Suspended,Wall" values_context="lamp_mount" match="key" />
+            <text key="ref" text="Reference number"/>
             <optional>
                 <combo key="opening_hours" text="Operation times" values="Mo-Fr 22:00-05:00" match="none" editable="true" values_no_i18n="true"/>
             </optional>


### PR DESCRIPTION
This pull request adds `ref=` to `highway=street_lamp` as described at https://wiki.openstreetmap.org/wiki/Tag:highway%3Dstreet_lamp .