### PR TITLE
Add chunk/key highchair

### DIFF
--- a/master_preset.xml
+++ b/master_preset.xml
@@ -1339,6 +1339,9 @@
   <chunk id="fountain_type">
         <combo key="fountain" text="Fountain type" values="yes,bubbler,nasone,nozzle,splash_pad" display_values="Yes,Bubbler,Nasone,Nozzle,Splash pad" />
   </chunk>
+  <chunk id="highchair">
+      <combo key="highchair" text="High chair for small children" values="yes,no,1,2,3,4,5,6,7,8,9,10" display_values="Yes,No,1,2,3,4,5,6,7,8,9,10" editable="true" values_sort="false"/>
+  </chunk>
   <!-- Groups -->
   <group name="Highways" icon="${highway_group}">
     <group name="Streets" icon="${highway_group}" items_sort="false" >
@@ -4301,6 +4304,7 @@
             <space/>
             <reference ref="internet_smoking"/>
             <reference ref="link_contact_address_payment"/>
+	    <reference ref="highchair" />
             <preset_link preset_name="Diet" />
         </item> <!-- Restaurant -->
         <item name="Fast Food" icon="${food_fast_food}" type="node,closedway,multipolygon" preset_name_label="true">
@@ -4318,6 +4322,7 @@
             <space/>
             <reference ref="internet_smoking"/>
             <reference ref="link_contact_address_payment"/>
+	    <reference ref="highchair" />
         </item> <!-- Fast Food -->
         <item name="Food Court" icon="${food_food_court}" type="node,closedway,multipolygon" preset_name_label="true">
             <link wiki="Tag:amenity=food_court"/>
@@ -4330,6 +4335,7 @@
             <space/>
             <reference ref="internet_smoking"/>
             <reference ref="link_contact_address_payment"/>
+	    <reference ref="highchair" />
             <preset_link preset_name="Diet" />
         </item> <!-- Food Court -->
         <item name="Cafe" icon="${food_cafe}" type="node,closedway,multipolygon" preset_name_label="true">
@@ -4346,6 +4352,7 @@
             <space/>
             <reference ref="internet_smoking"/>
             <reference ref="link_contact_address_payment"/>
+	    <reference ref="highchair" />
             <preset_link preset_name="Diet" />
         </item> <!-- Cafe -->
         <item name="Bubble Tea Cafe" icon="${food_bubble_tea}" type="node,closedway,multipolygon" preset_name_label="true">
@@ -4357,6 +4364,7 @@
             <space/>
             <reference ref="internet_smoking"/>
             <reference ref="link_contact_address_payment"/>
+	    <reference ref="highchair" />
         </item> <!-- Bubble Tea Cafe -->
         <item name="Ice cream" icon="${food_ice_cream}" type="node,closedway,multipolygon" preset_name_label="true">
             <link wiki="Tag:amenity=ice_cream"/>
@@ -4371,6 +4379,7 @@
             <space/>
             <reference ref="internet_smoking"/>
             <reference ref="link_contact_address_payment"/>
+	    <reference ref="highchair" />
             <preset_link preset_name="Diet" />
         </item> <!-- Ice cream -->
         <item name="Pub" icon="${food_pub}" type="node,closedway,multipolygon" preset_name_label="true">
@@ -4391,6 +4400,7 @@
                 <reference ref="lgbtq" />
             </optional>
             <reference ref="link_contact_address_payment"/>
+	    <reference ref="highchair" />
             <preset_link preset_name="Diet" />
         </item> <!-- Pub -->
         <item name="Beer Garden" icon="${food_biergarten}" type="node,closedway,multipolygon" preset_name_label="true">
@@ -4404,6 +4414,7 @@
             <space/>
             <reference ref="internet_smoking"/>
             <reference ref="link_contact_address_payment"/>
+	    <reference ref="highchair" />
             <preset_link preset_name="Diet" />
         </item> <!-- Beer Garden -->
         <item name="Bar" icon="${food_bar}" type="node,closedway,multipolygon" preset_name_label="true">
@@ -4421,6 +4432,7 @@
                 <reference ref="lgbtq" />
             </optional>
             <reference ref="link_contact_address_payment"/>
+	    <reference ref="highchair" />
             <preset_link preset_name="Diet" />
         </item> <!-- Bar -->
         <separator/>


### PR DESCRIPTION
This is my try at introducing the key [`highchair=*`](https://wiki.openstreetmap.org/wiki/Key:highchair) into the Vespucci presets.

I'm not that experienced yet in writing JOSM/Vespucci presets, so you should probably double check.

Some remarks:

- Should the `<chunk>` have an attribute `match=key` or `match=key!`?
- I'm not sure if it is really adequate to add the preset to beer gardens, pubs and bars. My thoughts:
  - beer gardens and pubs will be visited by whole families every then and when
  - According to the [wiki](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dbar) in a mediterranean context, a bar could be the place where you e.g. gather your espresso in the morning or have a small lunch.