### PR TITLE
Key crossing=* uses <combo> instead of <multiselect>

### DIFF
--- a/master_preset.xml
+++ b/master_preset.xml
@@ -238,18 +238,14 @@
         </optional>
     </chunk>
     <chunk id="crossing_type">    
-    	<multiselect key="crossing" text="Crossing type" values_context="pedestrian" text_context="pedestrian">
- 			<list_entry value="uncontrolled" short_description="Not controlled" icon="${crossing}"/>
- 			<list_entry value="traffic_signals" short_description="Traffic signals" icon="${crossing_traffic_signals}"/>
-			<list_entry value="island" short_description="Island (deprecated)" icon="${crossing_island}"/>
-			<list_entry value="unmarked" short_description="Unmarked" icon="${crossing_unmarked}"/>
-			<list_entry value="no" short_description="No crossing"/>
- 		</multiselect>
+	<combo key="crossing" text="Crossing type" values_context="pedestrian" text_context="pedestrian" values_sort="false"
+	    values="uncontrolled,traffic_signals,unmarked,no,island"
+	    display_values="Uncontrolled,Traffic signals,Unmarked,No crossing,Island (deprecated)"/>
         <check key="crossing:island" text="With island" />
         <optional>
             <combo key="crossing_ref" text="Crossing type name (UK)" values="zebra,pelican,toucan,puffin,pegasus,tiger" values_searchable="true"/>
         </optional>
- 	</chunk>
+    </chunk>
     <chunk id="railway_service">
         <combo key="service" text="Service type" values="yard,siding,spur,crossover" display_values="Yard,Siding,Spur,Crossover" values_context="railway" />
     </chunk>


### PR DESCRIPTION
According to my interpretation of https://wiki.openstreetmap.org/wiki/Key:crossing , the key `crossing=*` normally should get only one value. Therefore `<multiselect>` would be inappropriate, which I replaced with `<combo>`.

I renamed the text of `crossing=uncontrolled` from `Not controlled` to `Uncontrolled`.

I further put `crossing=island` to the bottom, since it is deprecated. Maybe we should remove this completely?

A further problem, not addressed in this PR, is: The wiki at https://wiki.openstreetmap.org/wiki/Key:crossing#Approved_tags mentions that `crossing=no` shall not be combined with `highway=crossing`. But this is what happens, when one chooses a crossing and then the type `no`. Could we in that case remove the `highway=crossing`?