### PR TITLE
Add location=* for recycling containers

### DIFF
--- a/master_preset.xml
+++ b/master_preset.xml
@@ -6422,6 +6422,9 @@
             <space/>
             <key key="amenity" value="recycling"/>
             <key key="recycling_type" value="container"/>
+            <optional>
+                <combo key="location" text="Location" values="underground,overground" display_values="underground,overground" values_context="pipeline" />
+            </optional>
             <reference ref="oh_wheelchair"/>
             <space/>
             <reference ref="recycling_accepted_material"/>


### PR DESCRIPTION
Analogously to StreetComplete, this PR adds the ability to mark recycling containers as underground (or explicitly as overground).

See also https://wiki.openstreetmap.org/wiki/StreetComplete/Quests#Released_quest_types (Full disclosure: I edited this page while creating this PR.)