### PR TITLE
genus=* for natural=tree, natural=tree_row

### DIFF
--- a/master_preset.xml
+++ b/master_preset.xml
@@ -724,10 +724,13 @@
         <text key="symbol" text="Symbol description"/>
         <text key="description" text="Description" length="255" />
     </chunk>
-    <chunk id="genus_species_taxon">
-        <text key="genus" text="Genus"/>
+    <chunk id="species_taxon">
         <text key="species" text="Species"/>
         <text key="taxon" text="Taxon"/>
+    </chunk>
+    <chunk id="genus_species_taxon">
+        <text key="genus" text="Genus"/>
+        <reference ref="species_taxon"/>
     </chunk>
     <chunk id="leaf">
         <combo key="leaf_type" text="Leaf type" values="broadleaved,needleleaved,mixed,leafless" display_values="Broadleaved,Needleleaved,Mixed,Leafless" values_searchable="true"/>

--- a/master_preset.xml
+++ b/master_preset.xml
@@ -732,6 +732,18 @@
         <text key="genus" text="Genus"/>
         <reference ref="species_taxon"/>
     </chunk>
+    <chunk id="tree_genus">
+        <combo key="genus" text="Genus (first part of scientific name)"
+	    values="Abies,Acer,Aesculus,Ananas,Betula,Carpinus,Cedrus,Celtis,Citrus,Cocos,Cydonia,Elaeis,Eucalyptus,Fraxinus,Ginkgo,Gleditsia,Juglans,Malus,Musa,Olea,Persea,Phoenix,Picea,Pinus,Platanus,Populus,Prunus,Pyrus,Quercus,Robinia,Salix,Sophora,Sorbus,Tilia,Ulmus"
+	    display_values="Abies (Fir),Acer (Maple),Aesculus (Horse chestnut / Buckeye),Ananas (Pineapple),Betula (Birch),Carpinus (Hornbeam),Cedrus (Cedar),Celtis (Hackberry / Nettle tree),Citrus (Citrus fruit),Cocos (Coconut tree),Cydonia (Quince),Elaeis (Oil palm),Eucalyptus,Fraxinus (Ash),Ginkgo,Gleditsia (Honey locust),Juglans (Walnut tree),Malus (Apple),Musa (Banana),Olea (Olive),Persea (Avocado),Phoenix (Date palm),Picea (Spruce),Pinus (Pine),Platanus,Populus (Aspen / Poplar / Cottonwood),Prunus (Plum / Cherry / Peach / Nectarine / Apricot / Almond),Pyrus (Pear),Quercus (Oak),Robinia (Locust),Salix (Willow / Sallow / Osier),Sophora,Sorbus (Whitebeam / Rowan / Service tree / Mountain-ash),Tilia (Linden / Lime / Basswood),Ulmus (Elm)"
+	    use_last_as_default="true"
+	    editable="false"
+	    values_searchable="true"/>
+    </chunk>
+    <chunk id="tree_genus_species_taxon">
+        <reference ref="tree_genus"/>
+        <reference ref="species_taxon"/>
+    </chunk>
     <chunk id="leaf">
         <combo key="leaf_type" text="Leaf type" values="broadleaved,needleleaved,mixed,leafless" display_values="Broadleaved,Needleleaved,Mixed,Leafless" values_searchable="true"/>
         <combo key="leaf_cycle" text="Leaf cycle" values_searchable="true">
@@ -10353,7 +10365,7 @@
             </optional>
             <text key="height" text="Height (meters)" length="7" />
             <text key="circumference" text="Circumference (meters)"/>
-            <reference ref="genus_species_taxon"/>
+            <reference ref="tree_genus_species_taxon"/>
             <reference ref="leaf"/>
             <optional>
             	<text key="diameter_crown" text="Crown diameter (meters)"/>
@@ -10373,7 +10385,7 @@
             <key key="natural" value="tree_row"/>
             <text key="height" text="Height (meters)" length="7" />
             <optional>
-            	<reference ref="genus_species_taxon"/>
+                <reference ref="tree_genus_species_taxon"/>
                 <reference ref="leaf"/>
             </optional>
         </item> <!-- Tree Row -->


### PR DESCRIPTION
This PR adds a selection of values for key [`genus=*`](https://wiki.openstreetmap.org/wiki/Key:genus) to be used in [`natural=tree`](https://wiki.openstreetmap.org/wiki/Tag:natural%3Dtree) and [`natural=tree_row`](https://wiki.openstreetmap.org/wiki/Tag:natural%3Dtree_row).

The list of values mostly consists of the top results of https://taginfo.openstreetmap.org/keys/genus#values (minus some non-tree genera), complemented by some further genera (Abies, Cydonia, Pyrus). Having these values should cover approx. 80% of all currently existing usages of `genus=*` in OSM.

The english names were taken from Wikipedia, sometimes they describe commonly known species of a genus, not the genus itself, e.g. for Prunus.

Since I'm neither a native English speaker, nor a biologist, this PR will probably contain some errors...