### PR TITLE
Move crossing=island to bottom of crossing=*

### DIFF
--- a/master_preset.xml
+++ b/master_preset.xml
@@ -250,9 +250,9 @@
         <multiselect key="crossing" text="Crossing type" values_context="pedestrian" text_context="pedestrian">
             <list_entry value="uncontrolled" short_description="Not controlled" icon="${crossing}"/>
             <list_entry value="traffic_signals" short_description="Traffic signals" icon="${crossing_traffic_signals}"/>
-            <list_entry value="island" short_description="Island (deprecated)" icon="${crossing_island}"/>
             <list_entry value="unmarked" short_description="Unmarked" icon="${crossing_unmarked}"/>
             <list_entry value="no" short_description="No crossing"/>
+            <list_entry value="island" short_description="Island (deprecated)" icon="${crossing_island}"/>
         </multiselect>
         <check key="crossing:island" text="With island" />
         <optional>


### PR DESCRIPTION
This PR moves the [deprecated `crossing=island`](https://wiki.openstreetmap.org/wiki/Tag:crossing%3Disland) to the bottom of the list of `crossing=*` in order to reduce its visibility.

This PR obsoletes https://github.com/simonpoole/beautified-JOSM-preset/pull/247 and https://github.com/simonpoole/beautified-JOSM-preset/pull/269 .