### PR TITLE
"payment:huaweipay" should read "payment:huawei_pay"

### DIFF
--- a/master_preset.xml
+++ b/master_preset.xml
@@ -10040,7 +10040,7 @@
             <check key="payment:clover" text="Clover" match="keyvalue" disable_off="true"/>
             <check key="payment:google_pay" text="Google Pay" match="keyvalue" disable_off="true"/>
             <check key="payment:grabpay" text="GrabPay" match="keyvalue" disable_off="true"/>
-            <check key="payment:huaweipay" text="Huawei Pay" match="keyvalue" disable_off="true"/>
+            <check key="payment:huawei_pay" text="Huawei Pay" match="keyvalue" disable_off="true"/>
             <check key="payment:samsung_pay" text="Samsung Pay" match="keyvalue" disable_off="true"/>
             <check key="payment:satispay" text="Satispay" match="keyvalue" disable_off="true"/>
             <check key="payment:twint" text="TWINT" match="keyvalue" disable_off="true"/>


### PR DESCRIPTION
"payment:huawei_pay" is the documented tag in the Wiki and also the one in use according to Taginfo statistics.