### PR TITLE
landuse=recreation_ground uses dog=*

### DIFF
--- a/master_preset.xml
+++ b/master_preset.xml
@@ -1109,7 +1109,6 @@
             <combo key="horse" text="Horse" values="yes,official,designated,permissive,destination,delivery,private,permit,no"
                 display_values="Yes,Official,Designated,Permissive,Destination,Delivery,Private,Permit required,No" values_context="access" match="key" values_sort="false"/>
             <reference ref="dog" />
-                display_values="Yes,Leashed,Unleashed,Official,Designated,Permissive,Private,Permit required,No" values_sort="false" values_context="access"  match="key" />
             <combo key="ski" text="Ski" values="yes,official,designated,permissive,private,permit,no" display_values="Yes,Official,Designated,Permissive,Private,Permit required,No" values_context="access" values_sort="false"/>
             <combo key="snowmobile" text="Snowmobile" values="yes,official,designated,permissive,destination,delivery,private,permit,no" 
                 display_values="Yes,Official,Designated,Permissive,Destination,Delivery,Private,Permit required,No" values_context="access" values_sort="false"/>

--- a/master_preset.xml
+++ b/master_preset.xml
@@ -10720,6 +10720,7 @@
             <space/>
             <key key="landuse" value="recreation_ground"/>
             <reference ref="optional_name"/>
+            <reference ref="dog"/>
         </item> <!-- Recreation Ground -->
         <separator/>
         <item name="Religious" icon="${landuse_religous}" type="closedway,multipolygon" preset_name_label="true">

--- a/master_preset.xml
+++ b/master_preset.xml
@@ -1100,11 +1100,15 @@
         <preset_link preset_name="Physical restrictions"/>
         <preset_link preset_name="Other mode restrictions"/>
     </chunk>
+    <chunk id="dog">
+        <combo key="dog" text="Dog" values="yes,leashed,unleashed,official,designated,permissive,private,no"
+            display_values="Yes,Leashed,Unleashed,Official,Designated,Permissive,Private,No" values_sort="false" values_context="access" match="key" />
+    </chunk>
     <chunk id="path_access_restrictions">
         <optional>
             <combo key="horse" text="Horse" values="yes,official,designated,permissive,destination,delivery,private,permit,no"
                 display_values="Yes,Official,Designated,Permissive,Destination,Delivery,Private,Permit required,No" values_context="access" match="key" values_sort="false"/>
-            <combo key="dog" text="Dog" values="yes,leashed,unleashed,official,designated,permissive,private,permit,no" 
+            <reference ref="dog" />
                 display_values="Yes,Leashed,Unleashed,Official,Designated,Permissive,Private,Permit required,No" values_sort="false" values_context="access"  match="key" />
             <combo key="ski" text="Ski" values="yes,official,designated,permissive,private,permit,no" display_values="Yes,Official,Designated,Permissive,Private,Permit required,No" values_context="access" values_sort="false"/>
             <combo key="snowmobile" text="Snowmobile" values="yes,official,designated,permissive,destination,delivery,private,permit,no" 

--- a/master_preset.xml
+++ b/master_preset.xml
@@ -1101,8 +1101,8 @@
         <preset_link preset_name="Other mode restrictions"/>
     </chunk>
     <chunk id="dog">
-        <combo key="dog" text="Dog" values="yes,leashed,unleashed,official,designated,permissive,private,no"
-            display_values="Yes,Leashed,Unleashed,Official,Designated,Permissive,Private,No" values_sort="false" values_context="access" match="key" />
+        <combo key="dog" text="Dog" values="yes,leashed,unleashed,designated,permissive,private,no"
+            display_values="Yes,Leashed,Unleashed,Designated,Permissive,Private,No" values_sort="false" values_context="access" match="key" />
     </chunk>
     <chunk id="path_access_restrictions">
         <optional>


### PR DESCRIPTION
This PR is a replacement for https://github.com/simonpoole/beautified-JOSM-preset/pull/251 .

This PR contains the following changes:

1. Move `dog=*` into its own chunk.
2. Add `dog=*` to `landuse=recreation_ground`
3. Remove `dog=official` since there are ~~0~~, now 3 uses for it according to [TagInfo](https://taginfo.openstreetmap.org/keys/dog#values) (IMHO we could reduce the set of available values even more...)

For reference check https://wiki.openstreetmap.org/wiki/Key:dog