### PR TITLE
Extend amenity=bench, leisure=picnic_table

### DIFF
--- a/master_preset.xml
+++ b/master_preset.xml
@@ -1437,7 +1437,7 @@
         </optional>
     </chunk>
     <chunk>
-        <check key="backrest" text="Backrest" disable_off="true"/>
+        <check key="backrest" text="Backrest"/>
     </chunk>
     <!-- Groups -->
     <group name="Highways" icon="${highway_group}">
@@ -5235,6 +5235,7 @@
             <link wiki="Tag:leisure=picnic_table"/>
             <space/>
             <key key="leisure" value="picnic_table"/>
+            <reference ref="backrest"/>
             <check key="covered" text="Covered"/>
         </item> <!-- Picnic Table -->
         <item name="Public Grill" icon="${tourist_bbq}" type="node,closedway,multipolygon" preset_name_label="true">
@@ -6599,9 +6600,9 @@
             <link wiki="Tag:leisure=bleachers"/>
             <space/>
             <key key="leisure" value="bleachers"/>
+            <reference ref="backrest"/>
             <reference ref="material"/>
             <reference ref="colours" />
-            <check key="backrest" text="Backrest" />
             <optional>
                 <reference ref="name_operator_oh_wheelchair" />
             </optional>

--- a/master_preset.xml
+++ b/master_preset.xml
@@ -5236,6 +5236,8 @@
             <space/>
             <key key="leisure" value="picnic_table"/>
             <reference ref="backrest"/>
+            <reference ref="material"/>
+            <reference ref="colours" />
             <check key="covered" text="Covered"/>
         </item> <!-- Picnic Table -->
         <item name="Public Grill" icon="${tourist_bbq}" type="node,closedway,multipolygon" preset_name_label="true">

--- a/master_preset.xml
+++ b/master_preset.xml
@@ -1436,7 +1436,7 @@
             <check key="ferry" text="Ferry" disable_off="true"/>
         </optional>
     </chunk>
-    <chunk>
+    <chunk id="backrest">
         <check key="backrest" text="Backrest"/>
     </chunk>
     <!-- Groups -->

--- a/master_preset.xml
+++ b/master_preset.xml
@@ -6597,6 +6597,9 @@
             <reference ref="material"/>
             <reference ref="colours" />
             <combo key="seats" text="Seats count" values="1,2,3,4,5,6,7,8,9,10"/>
+            <optional>
+                <check key="covered" text="Covered"/>
+            </optional>
         </item> <!-- Bench -->
         <item name="Bleachers" icon="${amenity_bleachers}" type="node,closedway,multipolygon" preset_name_label="true">
             <link wiki="Tag:leisure=bleachers"/>

--- a/master_preset.xml
+++ b/master_preset.xml
@@ -1436,6 +1436,9 @@
             <check key="ferry" text="Ferry" disable_off="true"/>
         </optional>
     </chunk>
+    <chunk>
+        <check key="backrest" text="Backrest" disable_off="true"/>
+    </chunk>
     <!-- Groups -->
     <group name="Highways" icon="${highway_group}">
     <group name="Streets" icon="${highway_group}" items_sort="false" >
@@ -6587,7 +6590,7 @@
             <link wiki="Tag:amenity=bench"/>
             <space/>
             <key key="amenity" value="bench"/>
-            <check key="backrest" text="Backrest" disable_off="true"/>
+            <reference ref="backrest"/>
             <reference ref="material"/>
             <reference ref="colours" />
             <combo key="seats" text="Seats count" values="1,2,3,4,5,6,7,8,9,10"/>


### PR DESCRIPTION
This PR extends `amenity=bench` and `leisure=picnic_table`.

Changes to both:
- Move `backrest=yes/no` to chunk (now also used in `leisure=bleachers`)

Changes to `leisure=picnic_table` (motivated by numbers from [taginfo](https://taginfo.openstreetmap.org/tags/leisure=picnic_table#combinations))
- Add `backrest=yes/no`
- Add `material=*`
- Add `colour=*`

Changes to `amenity=bench`:
- Add optional `covered=yes/no`

