### PR TITLE
Allow non-integer values for min_age=* and max_age=* (fix #276)

### DIFF
--- a/master_preset.xml
+++ b/master_preset.xml
@@ -283,10 +283,10 @@
                display_values="North,East,South,West,0°,90°,180°,270°,Forward,Backward" values_sort="false" />
     </chunk>
     <chunk id="min_age">
-        <text key="min_age" text="Minimum age" value_type="integer"/>
+        <text key="min_age" text="Minimum age"/>
     </chunk>
     <chunk id="max_age">
-        <text key="max_age" text="Maximum age" value_type="integer"/>
+        <text key="max_age" text="Maximum age"/>
     </chunk>
     <chunk id="min_max_age">
         <reference ref="min_age"/>


### PR DESCRIPTION
This PR fixes https://github.com/simonpoole/beautified-JOSM-preset/issues/276