### PR TITLE
Implement advanced cycle barrier tagging

### DIFF
--- a/master_preset.xml
+++ b/master_preset.xml
@@ -375,13 +375,16 @@
         <reference ref="toilets"/>
         <combo key="toilets:access" text="Toilet access" values="yes,permissive,customers,private" display_values="Public,Permissive,Customers,Private" match="none"/>
     </chunk>
-    <chunk id="wheelchair">
+    <chunk id="essential_wheelchair">
         <combo key="wheelchair" text="Wheelchairs" match="none" values_searchable="true" values_sort="false">
             <list_entry value="designated" short_description="Dedicated facilities"/>
             <list_entry value="yes" short_description="Unrestricted access"/>
             <list_entry value="limited" short_description="Partial access"/>
             <list_entry value="no" short_description="No access"/>
         </combo>
+    </chunk>
+    <chunk id="wheelchair">
+        <reference ref="essential_wheelchair"/>
         <optional>
             <text key="wheelchair:description" text="Wheelchair access details" length="255" i18n="true"/>
             <text key="wheelchair:entrance_width" text="Entrance width in cm"/>

--- a/master_preset.xml
+++ b/master_preset.xml
@@ -377,10 +377,10 @@
     </chunk>
     <chunk id="wheelchair">
         <combo key="wheelchair" text="Wheelchairs" match="none" values_searchable="true" values_sort="false">
-        <list_entry value="designated" short_description="Dedicated facilities"/>
-        <list_entry value="yes" short_description="Unrestricted access"/>
-        <list_entry value="limited" short_description="Partial access"/>
-        <list_entry value="no" short_description="No access"/>
+            <list_entry value="designated" short_description="Dedicated facilities"/>
+            <list_entry value="yes" short_description="Unrestricted access"/>
+            <list_entry value="limited" short_description="Partial access"/>
+            <list_entry value="no" short_description="No access"/>
         </combo>
         <optional>
             <text key="wheelchair:description" text="Wheelchair access details" length="255" i18n="true"/>

--- a/master_preset.xml
+++ b/master_preset.xml
@@ -657,6 +657,9 @@
             <text key="height" text="Height (meters)" length="7"/>
         </optional>
     </chunk>
+    <chunk id="maxwidthphysical">
+        <text key="maxwidth:physical" text="Physical max. width (meters)" length="7"/>
+    </chunk>
     <chunk id="optional_maxwidth">
         <optional>
             <text key="maxwidth" text="Max. width (meters)" length="7"/>
@@ -2411,7 +2414,7 @@
                 <list_entry value="foldable" display_value="Foldable (hinge at base)" />
             </combo>
             <optional>
-                <reference ref="optional_maxwidth"/>
+                <reference ref="maxwidthphysical"/>
                 <text key="spacing" text="Spacing between grids (meters)" length="7"/>
                 <text key="opening" text="Opening width of grids (meters)" length="7"/>
                 <text key="overlap" text="Overlap width of grids (meters)" length="7"/>

--- a/master_preset.xml
+++ b/master_preset.xml
@@ -2380,11 +2380,11 @@
         <item name="Cycle Barrier" icon="${barrier_cycle_barrier}" type="node" preset_name_label="true">
             <link wiki="Tag:barrier=cycle_barrier"/>
             <key key="barrier" value="cycle_barrier"/>
-            <optional>
-                <reference ref="optional_maxwidth"/>
-                <reference ref="material"/>
-            </optional>
-            <reference ref="vehicle_access" />
+            <combo key="bicycle" text="Bicycle access" values_context="access" values_sort="false">
+                <list_entry value="yes" display_value="Yes" />
+                <list_entry value="no" display_value="No" />
+                <list_entry value="dismount" display_value="Dismount" />
+            </combo>
             <optional text="Non-motorized traffic:">
                 <checkgroup text="Non-motorized traffic" columns="2">
                     <check key="foot" text="Foot" icon="${no_walking}" />
@@ -2392,9 +2392,29 @@
                 </checkgroup>
                 <space />
                 <reference ref="wheelchair" />
-                <combo key="bicycle" text="Bicycle" values="dismount,no" display_values="Dismount,No" values_context="access" values_sort="false" />
+                <reference ref="check_access_motor" />
             </optional>
-            <reference ref="check_access_motor" />
+            <combo key="cycle_barrier" text="Type" values_searchable="true" values_sort="false">
+                <list_entry value="single" display_value="Single" />
+                <list_entry value="double" display_value="Double" />
+                <list_entry value="triple" display_value="Triple" />
+                <list_entry value="diagonal" display_value="Diagonal" />
+                <list_entry value="squeeze" display_value="Squeeze" />
+            </combo>
+            <combo key="cycle_barrier:installation" text="Installation" values_searchable="true" values_sort="false">
+                <list_entry value="fixed" display_value="Fixed to the ground" />
+                <list_entry value="openable" display_value="Openable (e.g. like swing gate)" />
+                <list_entry value="removable" display_value="Removable" />
+                <list_entry value="foldable" display_value="Foldable (hinge at base)" />
+            </combo>
+            <optional>
+                <reference ref="optional_maxwidth"/>
+                <text key="spacing" text="Spacing between grids (meters)" length="7"/>
+                <text key="opening" text="Opening width of grids (meters)" length="7"/>
+                <text key="overlap" text="Overlap width of grids (meters)" length="7"/>
+                <text key="corners" text="Corners" value_type="integer"/>
+                <reference ref="material"/>
+            </optional>
         </item> <!-- Cycle Barrier -->
         <item name="Cattle Grid" icon="${barrier_cattle_grid}" type="node" preset_name_label="true">
             <link wiki="Tag:barrier=cattle_grid"/>

--- a/master_preset.xml
+++ b/master_preset.xml
@@ -2394,7 +2394,7 @@
                     <check key="horse" text="Horse" icon="${no_riding}" />
                 </checkgroup>
                 <space />
-                <reference ref="wheelchair" />
+                <reference ref="essential_wheelchair" />
                 <reference ref="check_access_motor" />
             </optional>
             <combo key="cycle_barrier" text="Type" values_searchable="true" values_sort="false">


### PR DESCRIPTION
This PR tries to improve tagging of `barrier=cycle_barrier`. It was mainly inspired by the [approved proposal for advanced cycle barrier tagging](https://wiki.openstreetmap.org/w/index.php?oldid=2190485) but contains other changes as well.

This PR does the following:

- Change `barrier=cycle_barrier`
  - Add `cycle_barrier=*`
  - Add `cycle_barrier:installation=*`
  - Add `spacing=*`, `opening=*`, `overlap=*`, `corners=*`
  - Move up `bicycle=*` and add option `bicyle=yes`
  - Move down `maxwidth=*`, `material=*`
  - Remove vehicle=* ([taginfo](https://taginfo.openstreetmap.org/tags/barrier=cycle_barrier#combinations) says it's not used in combination with barrier=cycle_barrier)
  - Remove some wheelchair tags (`wheelchair:description=*`, `wheelchair:entrance_width=*`, `wheelchair:step_height=*`)
  - Use `maxwidth:physical=*` instead of `maxwidth=*` according to the [`barrier=cycle_barrier` wiki page](https://wiki.openstreetmap.org/wiki/Tag:barrier%3Dcycle_barrier)
- Create a new chunk `essential_wheelchair` that corresponds to chunk `wheelchair` minus the optional tags (`wheelchair:description=*`, `wheelchair:entrance_width=*`, `wheelchair:step_height=*`)
- Create a new chunk for `maxwidth:physical=*`
- Cosmetic changes