### PR TITLE
highway=street_lamp: Add optional key operator=...

### DIFF
--- a/master_preset.xml
+++ b/master_preset.xml
@@ -11119,6 +11119,7 @@
                 <text key="light:direction" text="Direction in degrees" match="key"/>
                 <text key="light:count" text="Number of lamps" match="key" value_type="integer"/>
                 <text key="ref" text="Ref"/>
+                <text key="operator" text="Operator"/>
                 <combo key="opening_hours" value_type="opening_hours" text="Operation times" values="Mo-Fr 22:00-05:00" match="none" editable="true" values_no_i18n="true"/>
             </optional>
         </item> <!-- Street Lamp -->


### PR DESCRIPTION
This PR adds an optional `operator=...` to `highway=street_lamp`.