### PR TITLE
Modify sac_scale and trail visibility

### DIFF
--- a/master_preset.xml
+++ b/master_preset.xml
@@ -3552,16 +3552,24 @@
                 <check key="informal" text="Informal" />
                 <reference ref="highway_additional_oneway_lit_width"/>
                 <combo key="sac_scale" text="SAC Scale" values_searchable="true" values_sort="false">
-                    <list_entry value="hiking" display_value="T1 - hiking trail" short_description="Trail well cleared. Area flat or slightly sloped, no fall hazard"/>
-                    <list_entry value="mountain_hiking" display_value="T2 - mountain hiking trail" short_description="Trail with continuous line and balanced ascent. Terrain partially steep, fall hazard possible"/>
-                    <list_entry value="demanding_mountain_hiking" display_value="T3 - difficult, exposed hiking trail" short_description="exposed sites may be secured with ropes or chains, possible need to use hands for balance. Partly exposed sites with fall hazard, scree, pathless jagged rocks"/>
-                    <list_entry value="alpine_hiking" display_value="T4 - difficult, exposed, steep alpine trail" short_description="sometimes need for hand use to get ahead. Terrain quite exposed, precarious grassy acclivities, jagged rocks, facile snow-free glaciers"/>
-                    <list_entry value="demanding_alpine_hiking" display_value="T5 - difficult alpine trail with climbing" short_description="single plainly climbing up to second grade. Exposed, demanding terrain, jagged rocks, few dangerous glacier and snow"/>
-                    <list_entry value="difficult_alpine_hiking" display_value="T6 - hazardous alpine trail with climbing" short_description="climbing up to second grade. Often very exposed, precarious jagged rocks, glacier with danger to slip and fall"/>
+                    <list_entry value="strolling" display_value="smooth strolling trail" short_description="Smooth trail with no obstacles usually wide enough to be walked side-by-side. No exposed areas. Terrain level; no risk of falling or tripping over minor obstacles." />
+                    <list_entry value="hiking" display_value="T1 - hiking trail" short_description="Trail well cleared or with rather minor obstacles like roots, usually walked single file. Exposed areas well secured. Terrain level or inclined; no risk of falling with appropriate behaviour." />
+                    <list_entry value="mountain_hiking" display_value="T2 - mountain hiking trail" short_description="Continuous trail, with somewhat bigger obstacles like stones, smaller rocks. Exposed areas made more secure. Terrain steep in places and may pose fall hazards." />
+                    <list_entry value="demanding_mountain_hiking" display_value="T3 - difficult, exposed hiking trail" short_description="Obstacles like boulders. Exposed areas ordinarily secured with fixed ropes or chains. Use of hands for balance potentially needed. Portions of the route exposed with danger of falling. Trail may have unmarked portions and cross fields of loose scree or talus." />
+                    <list_entry value="alpine_hiking" display_value="T4 - difficult, exposed, steep alpine trail" short_description="Use of hands needed in order to advance in certain places. Terrain already quite exposed, including steep grassy pitches, talus slopes, easy snowfields, or snow-free glacier crossings." />
+                    <list_entry value="demanding_alpine_hiking" display_value="T5 - difficult alpine trail with climbing" short_description="Individual easy climbing sections.	Exposed and demanding terrain. May include steep rock scrambles, glaciers and snowfields with risk of sliding." />
+                    <list_entry value="difficult_alpine_hiking" display_value="T6 - hazardous alpine trail with climbing" short_description="Includes climbing pitches up to UIAA grade II.	Severe exposure. Difficult craggy terrain. Glaciers with high risk of sliding." />
                 </combo>
                 <reference ref="mtb_scale"/>
                 <reference ref="trailblazed" />
-                <combo key="trail_visibility" text="Visibility" values="excellent,good,intermediate,bad,horrible,no" display_values="Excellent,Good,Intermediate,Bad,Horrible,Not visible" values_context="trail_visibility" values_sort="false"/>
+                <combo key="trail_visibility" text="Visibility" values_searchable="true" values_context="trail_visibility" values_sort="false">
+                    <list_entry value="excellent" display_value="Always clearly visible trail" short_description="Unambiguous path or markers everywhere" />
+                    <list_entry value="good" display_value="Always visible trail" short_description="Path or next marker always visible, but sometimes has to be searched for" />
+                    <list_entry value="intermediate" display_value="Mostly visible trail" short_description="Path (or markers) mostly visible" />
+                    <list_entry value="bad" display_value="Sometimes invisible trail" short_description="Path (or markers) sometimes invisible/absent, route partly pathless" />
+                    <list_entry value="horrible" display_value="Often invisible trail" short_description="Often pathless without visible markers" />
+                    <list_entry value="no" display_value="Mostly or wholly invisible trail" short_description="Mostly pathless or no markers" />
+                </combo>
                 <reference ref="footway_accessibility"/>
                 <reference ref="handrail"/>
             </optional>


### PR DESCRIPTION
Thiscombines these two proposed changes to JOSM:
https://github.com/JOSM/josm/pull/146
https://github.com/JOSM/josm/pull/145

It updates trail_visibility to wiki and makes the keys more understandable (how is one suppposed to understand a difference between bad and horrible)?

The one about sac_scale implements an approved proposal that added strolling to sac_scale: https://wiki.openstreetmap.org/wiki/Proposal:Add_strolling_to_sac_scale_and_some_further_refinements

Over time, the definition of the scale evolved, which was also codifiedby the approval process, so updating the wording to the current state of affairs too.