### PR TITLE
vacant objects do not need opening hours etc

### DIFF
--- a/master_preset.xml
+++ b/master_preset.xml
@@ -13911,7 +13911,9 @@
             <link wiki="Tag:shop=vacant"/>
             <space/>
             <key key="shop" value="vacant"/>
-            <reference ref="name_oh_wheelchair_level"/>
+            <optional>
+                <reference ref="name_oh_wheelchair_level"/>
+            </optional>
             <reference ref="link_contact_address"/>
             <preset_link preset_name="Shop disused" text="Similar but different tags:" alternative="true" />
         </item> <!-- Vacant -->
@@ -16672,7 +16674,9 @@
             <link wiki="Tag:office=vacant"/>
             <space/>
             <key key="office" value="vacant"/>
-            <reference ref="name_oh_wheelchair_level"/>
+            <optional>
+                <reference ref="name_oh_wheelchair_level"/>
+            </optional>
             <reference ref="link_contact_address"/>
         </item> <!-- Vacant -->
     </group> <!-- Offices -->


### PR DESCRIPTION
admittedly not tested

also, looking at it again: maybe level should stay in non-optional ones?

(after looking at area from https://github.com/MarcusWolschon/osmeditor4android/issues/2828#issuecomment-2724517556 I decided to fix some errors, and what Vespucci reported as problem turned out to be a false positive)