### PR TITLE
use trolley:deposit=* instead of a fee=*

### DIFF
--- a/master_preset.xml
+++ b/master_preset.xml
@@ -10105,7 +10105,7 @@
             <space/>
             <key key="amenity" value="trolley_bay"/>
             <text key="operator" text="Operator"/>
-            <reference ref="fee"/>
+            <check key="trolley:deposit" text="Coin deposit"/>
             <check key="covered" text="Covered"/>
             <check key="indoor" text="Located inside a building?" disable_off="true" match="none"/>
             <reference ref="level" />


### PR DESCRIPTION
Because:

- [amenity=trolley_bay](https://wiki.openstreetmap.org/wiki/Tag:amenity=trolley_bay) wiki does not specify `fee=*` as a tag to be used in combination (nor does its taginfo show `fee=*` being used)
- `fee=yes` would be incorrect for those **deposits** in trolleys (as you do get your money back when you return the trolley)
- Wiki does document [trolley:deposit=*](https://wiki.openstreetmap.org/wiki/Key:trolley:deposit) as a tag to be used in combination, so let's use that instead.
