### PR TITLE
Add surface=laterite to surface presets

### DIFF
--- a/master_preset.xml
+++ b/master_preset.xml
@@ -133,7 +133,8 @@
         <list_entry value="sand" short_description="Sand"/>
         <list_entry value="ground" short_description="Ground"/>
         <list_entry value="dirt" short_description="Dirt"/>
-        <list_entry value="mud" short_description="Mud"/>    
+        <list_entry value="laterite" short_description="Laterite"/>
+        <list_entry value="mud" short_description="Mud"/>
     </chunk>
     <chunk id="smoothness_values">
         <list_entry value="excellent" short_description="Thin Rollers: rollerblade, skateboard"/>


### PR DESCRIPTION
\`surface=laterite\` was approved via OSM's proposal process ([Proposal:Surface=laterite](https://wiki.openstreetmap.org/wiki/Proposal:Surface%3Dlaterite), 29-0-0) and is documented at [Tag:surface=laterite](https://wiki.openstreetmap.org/wiki/Tag:surface%3Dlaterite).

Adds it to the \`surface_values\` chunk, labelled "Laterite", between \`dirt\` and \`mud\` alongside the other natural soil surfaces.